### PR TITLE
add missing menu

### DIFF
--- a/lcc_members/views/crm_team_menus.xml
+++ b/lcc_members/views/crm_team_menus.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="action_Équipes commerciales_form_view" model="ir.actions.act_window">
+        <field name="name">Équipes commerciales</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">crm.team</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html"><p class="o_view_nocontent_smiling_face">
+                    Définissez une nouvelles Equipe de Vente
+                </p><p>
+                    Use Sales Teams to organize your sales departments.
+                    Each channel will work with a separate pipeline.
+                </p>
+            
+        </field>
+    </record>
+
+    <menuitem action="action_Équipes commerciales_form_view"
+              name="Groupes locaux"
+              id="menu_action_Groupes locaux_form"
+parent=""              sequence="10"
+              groups=""
+              />
+</odoo>

--- a/lcc_members/views/res_partner_category_menus.xml
+++ b/lcc_members/views/res_partner_category_menus.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="action_Étiquettes de contact_form_view" model="ir.actions.act_window">
+        <field name="name">Étiquettes de contact</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">res.partner.category</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html"><p class="o_view_nocontent_smiling_face">
+                Créer une nouvelle étiquette de contact
+              </p><p>
+                Gérez les étiquettes de contact pour mieux les classer à des fins de suivi et d'analyse.
+              </p>
+            
+        </field>
+    </record>
+
+    <menuitem action="action_Étiquettes de contact_form_view"
+              name="Etiquettes"
+              id="menu_action_Etiquettes_form"
+parent=""              sequence="10"
+              groups=""
+              />
+</odoo>


### PR DESCRIPTION
@njeudy I have added 2 missing menu.
#38
- crm-team regarding local group list (I have some issues linking the code to the other files
- Res_partner category menu  regarding Tag list (I have some issues linking the code to the other files
pour #23
- member_type code seems to be in the module but not display
- tag menu seems to be in the module but not display