### PR TITLE
[FIX] let exceptions to be translated to HTTP Errors

### DIFF
--- a/lcc_lokavaluto_app_connection/http.py
+++ b/lcc_lokavaluto_app_connection/http.py
@@ -118,4 +118,21 @@ def __init__(self, httprequest):
     self._determine_context_lang()
 
 
+def dispatch(self):
+    try:
+        return super(HttpRestRequest, self).dispatch()
+    except Exception as exc:
+        return self._handle_exception(exc)
+
+
+class FakeWebSite(object):
+    def website_domain(self):
+        return []
+
+    def is_publisher(self):
+        return False
+
+
 HttpRestRequest.__init__ = __init__
+HttpRestRequest.dispatch = dispatch
+HttpRestRequest.website = FakeWebSite()


### PR DESCRIPTION
Code in ``base_rest`` to translate standard odoo exception to HTTP
errors exists but was not triggered. We needed to go further in
the monkey-patching process to allow this feature to actually work.

Signed-off-by: Valentin Lab <valentin.lab@kalysto.org>