### PR TITLE
[FIX] access rule did not apply without storing value

### DIFF
--- a/lcc_members/models/res_partner.py
+++ b/lcc_members/models/res_partner.py
@@ -159,10 +159,10 @@ class res_partner(models.Model):
         string=_("Manage structure's public profile")
     )
     can_edit_main_profile_ids = fields.Many2many(
-        "res.partner", compute="_compute_can_edit", string="Can edit main profile"
+        "res.partner", store=True, compute="_compute_can_edit", string="Can edit main profile"
     )
     can_edit_public_profile_ids = fields.Many2many(
-        "res.partner", compute="_compute_can_edit", string="Can edit public profile"
+        "res.partner", store=True, compute="_compute_can_edit", string="Can edit public profile"
     )
     want_newsletter_subscription = fields.Boolean(
         string=_("Want Newsletters Subscription")
@@ -173,7 +173,7 @@ class res_partner(models.Model):
         domain=[("partner_profile.ref", "=", "partner_profile_position")]
     )
 
-    @api.depends("other_contact_ids")
+    @api.depends("other_contact_ids", "other_contact_ids.edit_structure_main_profile", "other_contact_ids.edit_structure_public_profile")
     def _compute_can_edit(self):
         for partner in self:
             partner.can_edit_main_profile_ids = partner.child_ids.filtered(


### PR DESCRIPTION
- Apply access rules correctly

```
<record model="ir.rule" id="res_partner_portal_members_rule">
        <field name="name">res_partner: portal: read/write access on my profiles</field>
        <field name="model_id" ref="base.model_res_partner"/>
        <field name="domain_force">['|','|',('contact_id', '=', user.partner_id.id),
                                    ('can_edit_main_profile_ids', 'in', [user.partner_id.id]),
                                    ('can_edit_public_profile_ids', 'in', [user.partner_id.id])]</field>
        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
        <field name="perm_create" eval="False"/>
        <field name="perm_unlink" eval="False"/>
    </record>
```