### PR TITLE
[FIX] lcc_members_portal: fix membership product issue with multi company

### DIFF
--- a/lcc_members_portal/controllers/portal_private_registration.py
+++ b/lcc_members_portal/controllers/portal_private_registration.py
@@ -40,7 +40,7 @@ class PortalPrivateRegistration(CustomerPortal):
     def get_private_membership_products(self):
         product_obj = request.env["product.template"]
         products = product_obj.sudo().get_private_membership_products(
-            request.env.user.partner_id.company_id.id
+            request.website.company_id.id
         )
         return products
 


### PR DESCRIPTION
for current mlc, membership portal process is now centralized in the main company website, then the retrival of the right membership products should not consider the company-id anymore.