### PR TITLE
[FIX] lcc_members: missing dependency to membership_extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.idea/

--- a/lcc_members/__manifest__.py
+++ b/lcc_members/__manifest__.py
@@ -18,6 +18,7 @@
         "partner_profiles",
         "partner_profiles_portal",
         "membership",
+        "membership_extension",
         "complementary_contact_data",
         "base_address_city",
         "base_geolocalize",


### PR DESCRIPTION
Issue when: 
 - starting an environment from scratch using odoo image docker.0k.io/mirror/odoo:rc_12.0-MYC-INIT-3.7
 - trying to install module `lcc_members`

Module fails to install because of a missing field:
```
Field `category_id` does not exist

Error context:
View `membership_line.view.form`
[view_id: 1094, xml_id: n/a, model: membership.membership_line, parent_id: n/a]
None" while parsing /opt/odoo/auto/lokavaluto/lcc_members/views/membership_lines.xml:19, near
```
This field is added to the model membership_line by the OCA addon `membership_extension`

Adding this addon to dependencies list fixes the issue.