### PR TITLE
[FIX] lcc_cyclos_base: prevent displaying the cyclos account creation button to unauthorized user

### DIFF
--- a/lcc_cyclos_base/views/res_partner_view.xml
+++ b/lcc_cyclos_base/views/res_partner_view.xml
@@ -9,7 +9,7 @@
       <xpath expr="//field[@name='lcc_backend_ids']" position="after">
         <button name="cyclos_add_user" string="Create new Cyclos Wallet" class="oe_highlight"
           type="object" attrs="{'invisible': [('is_main_profile','=',False)]}"
-          group="group_wallet_accounts_manager" />
+          groups="lcc_lokavaluto_app_connection.group_wallet_accounts_manager" />
       </xpath>
     </field>
   </record>


### PR DESCRIPTION
Will avoid displaying the button to people outside the group.