### PR TITLE
[FIX] lcc_cyclos_base: use ``transaction`` id rather than ``transfer`…

### DIFF
--- a/lcc_cyclos_base/models/company.py
+++ b/lcc_cyclos_base/models/company.py
@@ -127,7 +127,7 @@ class Company(models.Model):
 
         # Set all the search criteria in the REST request entrypoint
         entrypoint = (
-            "/transfers?datePeriod=%s&orderBy=dateAsc&toAccountTypes=debit"
+            "/transactions?datePeriod=%s&orderBy=dateAsc&toAccountTypes=debit"
             % encoded_date
         )
 


### PR DESCRIPTION
…` cyclos object