### PR TITLE
[FIX] lcc_lokavaluto_app_connection: repair ``/get_recipient_by_uri``…

### DIFF
--- a/lcc_lokavaluto_app_connection/services/partner_services.py
+++ b/lcc_lokavaluto_app_connection/services/partner_services.py
@@ -280,6 +280,10 @@ class PartnerService(Component):
             request.params["backend_keys"]
         )
 
+        ## XXXvlab: temporary fix to work with cyclos
+        if "@" in request.params["data"]["rpb"]:
+            request.params["data"]["rpb"] = request.params["data"]["rpb"].split("@", 1)[0]
+
         backend_types = [key.split(":", 1)[0] for key in backend_keys]
         domain = [
             ("status", "=", "active"),


### PR DESCRIPTION
… for cyclos

The syntax of ids for account was not clear nor fixed, and cyclos would append ``@<SERVER:PORT>`` to its id compared to what is currently stored in ``res.partner.backend``'s ``name``.