### PR TITLE
[IMP] lcc_members : auth signup page do not display fields firstname and name when only_passwords

### DIFF
--- a/lcc_members/views/auth_signup_login_template.xml
+++ b/lcc_members/views/auth_signup_login_template.xml
@@ -2,13 +2,13 @@
 <odoo>
     <template id="auth_signup_lcc_fields" inherit_id="auth_signup.fields" name="Add lcc custom fields to Auth SignUp">
         <xpath expr="//div[hasclass('mb-3','field-name')]" position="replace">
-            <div class="mb-3 field-firstname">
+            <div class="mb-3 field-firstname" t-if="not only_passwords">
                 <label for="firstname">Your Firstname</label>
                 <input type="text" name="firstname" t-att-value="firstname" id="firstname" class="form-control form-control-sm" placeholder="e.g. John Doe"
                     required="required" t-att-readonly="'readonly' if only_passwords else None"
                     t-att-autofocus="'autofocus' if login and not only_passwords else None" />
             </div>
-            <div class="mb-3 field-lastname">
+            <div class="mb-3 field-lastname" t-if="not only_passwords">
                 <label for="name">Your Lastname</label>
                 <input type="text" name="lastname" t-att-value="lastname" id="lastname" class="form-control form-control-sm" placeholder="e.g. John Doe"
                     required="required" t-att-readonly="'readonly' if only_passwords else None"


### PR DESCRIPTION
Tickets : https://lokavaluto.fr/web#id=54&cids=1&model=helpdesk.ticket&view_type=form et https://lokavaluto.fr/web#id=2420&cids=1&menu_id=144&action=977&model=project.task&view_type=form

![Capture d’écran du 2025-06-03 16-27-47](https://github.com/user-attachments/assets/36ce3d6a-e798-45ce-b6f3-e63f2f66fc21)

