### PR TITLE
[lcc_fss_base] display res_partner website field by default

### DIFF
--- a/lcc_fss_base/views/res_partner_view.xml
+++ b/lcc_fss_base/views/res_partner_view.xml
@@ -10,7 +10,6 @@
                 <!-- ################### -->
                 <!-- MAIN DISPLAY UPDATE -->
                 <!-- ################### -->
-                <xpath expr="//field[@name='website']" position="replace" />
                 <xpath expr="//field[@name='currency_exchange_office']" position="replace" />
                 <xpath expr="//field[@name='title']" position="replace" />
                 <xpath expr="//field[@name='function']" position="replace" />


### PR DESCRIPTION
Behavior remains the same for ssa drôme and cca44 with these PRs : https://github.com/Lokavaluto/ssa-dieulefit-addons/pull/2/files and https://github.com/Lokavaluto/cca44-addons/pull/7