### PR TITLE
16.0 move wallet pwd in res_partner_backend

### DIFF
--- a/lcc_comchain_base/migrations/16.0.1.2.0/post-migrate.py
+++ b/lcc_comchain_base/migrations/16.0.1.2.0/post-migrate.py
@@ -1,0 +1,34 @@
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    cr.execute("""
+        SELECT
+            odoo_wallet_partner_id,
+            tmp_comchain_odoo_wallet_password
+        FROM res_alt_currency
+        WHERE active=True AND engine='comchain'
+    """)
+
+    # Write Odoo Wallet password in the matching res_partner_backend
+    for (
+            odoo_wallet_partner_id,
+            tmp_comchain_odoo_wallet_password,
+    ) in cr.fetchall():
+        if not tmp_comchain_odoo_wallet_password:
+            continue
+
+        odoo_wallet_id = env["res.partner"].browse(odoo_wallet_partner_id).lcc_backend_ids[0].id
+        cr.execute(
+            f"UPDATE res_partner_backend\
+            SET comchain_wallet_pwd='{tmp_comchain_odoo_wallet_password}'\
+            WHERE id={odoo_wallet_id}")
+
+    # Clean res_alt_currency table
+    cr.execute("ALTER TABLE res_alt_currency DROP COLUMN tmp_comchain_odoo_wallet_password")

--- a/lcc_comchain_base/migrations/16.0.1.2.0/pre-migrate.py
+++ b/lcc_comchain_base/migrations/16.0.1.2.0/pre-migrate.py
@@ -1,0 +1,16 @@
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    # Save Odoo Wallet password for each alt currency
+    ## Create tmp column
+    cr.execute(
+        "ALTER TABLE res_alt_currency ADD tmp_comchain_odoo_wallet_password varchar(255)"
+    )
+
+    ## Copy the data
+    cr.execute(
+        "UPDATE res_alt_currency SET tmp_comchain_odoo_wallet_password = comchain_odoo_wallet_password"
+    )

--- a/lcc_comchain_base/models/res_alt_currency.py
+++ b/lcc_comchain_base/models/res_alt_currency.py
@@ -30,9 +30,6 @@ class AlternativeCurrency(models.Model):
     odoo_wallet_partner_id = fields.Many2one(
         "res.partner", string="Odoo Wallet Partner", tracking=True
     )
-    comchain_odoo_wallet_password = fields.Char(
-        string="Odoo wallet password", tracking=True
-    )
     message_from = fields.Char("Message from", default=_default_messages, tracking=True)
     message_to = fields.Char("Message to", default=_default_messages, tracking=True)
 

--- a/lcc_comchain_base/models/wallet.py
+++ b/lcc_comchain_base/models/wallet.py
@@ -123,12 +123,9 @@ class ResPartnerBackend(models.Model):
             return res
 
         # Get Odoo wallet
+        odoo_wallet = self.alt_currency_id.odoo_wallet_partner_id.lcc_backend_ids[0]
         try:
-            odoo_wallet = pyc3l.Wallet.from_json(
-                self.alt_currency_id.odoo_wallet_partner_id.lcc_backend_ids[
-                    0
-                ].comchain_wallet,
-            )
+            comchain_odoo_wallet = pyc3l.Wallet.from_json(odoo_wallet.comchain_wallet)
         except Exception as e:
             _logger.error(tools.format_last_exception())
             return {
@@ -138,9 +135,8 @@ class ResPartnerBackend(models.Model):
             }
 
         # Unlock Odoo wallet before sending a transaction
-        alt_currency = self.alt_currency_id
         try:
-            odoo_wallet.unlock(alt_currency.comchain_odoo_wallet_password)
+            comchain_odoo_wallet.unlock(odoo_wallet.comchain_wallet_pwd)
         except Exception as e:
             _logger.error(tools.format_last_exception())
             return {
@@ -150,9 +146,10 @@ class ResPartnerBackend(models.Model):
             }
 
         # Send a transaction
+        alt_currency = self.alt_currency_id
         response = ""
         try:
-            response = odoo_wallet.transferOnBehalfOf(
+            response = comchain_odoo_wallet.transferOnBehalfOf(
                 f"0x{alt_currency.safe_wallet_partner_id.lcc_backend_ids[0].comchain_id}",
                 f"0x{self.comchain_id}",
                 amount,

--- a/lcc_comchain_base/models/wallet.py
+++ b/lcc_comchain_base/models/wallet.py
@@ -30,6 +30,7 @@ class ResPartnerBackend(models.Model):
     comchain_credit_min = fields.Float(string="Min Credit limit", tracking=True)
     comchain_credit_max = fields.Float(string="Max Credit limit", tracking=True)
     comchain_message_key = fields.Char(string="Message keys", tracking=True)
+    comchain_wallet_pwd = fields.Char(string="Wallet Password")
 
     @property
     def comchain_wallet_parsed(self):

--- a/lcc_comchain_base/views/res_alt_currency.xml
+++ b/lcc_comchain_base/views/res_alt_currency.xml
@@ -13,7 +13,6 @@
                        placeholder="Select partner linked to safe wallet." />
 		<field name="odoo_wallet_partner_id"
                        placeholder="Select partner linked to Odoo wallet." />
-		<field name="comchain_odoo_wallet_password" password="True" />
 		<field name="last_block_checked_nb" />
 		<field name="message_from" />
 		<field name="message_to" />

--- a/lcc_comchain_base/views/wallet.xml
+++ b/lcc_comchain_base/views/wallet.xml
@@ -11,6 +11,7 @@
                 <group name="comchain_specific" string="Comchain specific"
                     attrs="{'invisible': [('type','!=','comchain')]}">
                     <field name="comchain_id" />
+                    <field name="comchain_wallet_pwd" password="True"/>
                     <field name="comchain_wallet" />
                     <field name="comchain_status" />
                     <field name="comchain_type" />


### PR DESCRIPTION
Cette PR déplace le champ password du wallet Odoo dans le model res.partner.backend .
Pourquoi ce travail ?
* ça a plus de sens que ce soit cet objet qui détienne ce champ
* car ça prépare la PR suivante qui permettra de régler le problème du manque de gas sur le wallet Odoo pour les rtansferOnBehalf
* elle ouvre la voie pour permettre à Odoo de lancer des transactions sur la Comchain, pourquoi pas avec le wallet de l'asso MLC (et là un vaste champ des possibles s'ouvre 🙂 )