### PR TITLE
16.0 cron check credit requests

### DIFF
--- a/lcc_comchain_base/__manifest__.py
+++ b/lcc_comchain_base/__manifest__.py
@@ -19,6 +19,7 @@
         "security/ir_rule.xml",
         "views/res_alt_currency.xml",
         "views/wallet.xml",
+        "views/credit_request.xml",
         "data/comchain_data.xml",
         "data/res_alt_currency_data.xml",
     ],

--- a/lcc_comchain_base/data/res_alt_currency_data.xml
+++ b/lcc_comchain_base/data/res_alt_currency_data.xml
@@ -10,5 +10,16 @@
             <field name="numbercall">-1</field>
             <field name="active">0</field>
         </record>
+
+	<record id="ir_cron_check_credit_request_in_error" model="ir.cron">
+            <field name="name">Alt Currency: check Comchain credit request in error</field>
+            <field name="model_id" ref="lcc_lokavaluto_app_connection.model_res_alt_currency" />
+            <field name="state">code</field>
+            <field name="code">model._cron_check_credit_requests_in_error()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">hours</field>
+            <field name="numbercall">-1</field>
+            <field name="active">0</field>
+        </record>
     </data>
 </odoo>

--- a/lcc_comchain_base/models/__init__.py
+++ b/lcc_comchain_base/models/__init__.py
@@ -1,3 +1,4 @@
 from . import res_alt_currency
 from . import res_partner
 from . import wallet
+from . import credit_request

--- a/lcc_comchain_base/models/credit_request.py
+++ b/lcc_comchain_base/models/credit_request.py
@@ -1,0 +1,30 @@
+import logging
+from ..utils import check_transaction_content
+from odoo import models
+
+_logger = logging.getLogger(__name__)
+
+class CreditRequest(models.Model):
+
+    _inherit = "credit.request"
+
+    def check_still_in_error(self) -> None:
+        """Check if this credit request is still in error."""
+        self.ensure_one()
+        if self.alt_currency_id.engine != "comchain":
+            return
+
+        if not self.transaction_data:
+            _logger.warning(
+                f"Credit request {self.id} has no transaction ID, cannot check it.",
+            )
+            return
+
+        if check_transaction_content(self.transaction_data, self.amount):
+            _logger.info(
+                f"Credit request {self.id} is still in error.",
+            )
+            return
+
+        # If we reach this point, the transaction is now valid
+        self.state = "done"

--- a/lcc_comchain_base/models/res_alt_currency.py
+++ b/lcc_comchain_base/models/res_alt_currency.py
@@ -175,3 +175,36 @@ class AlternativeCurrency(models.Model):
 
             # Send 0 unit transaction to himself to generate gas.
             odoo_wallet_1.send_nant_transaction(odoo_wallet_1, 0.00, message)
+
+    def _cron_check_credit_requests_in_error(self):
+        """Check credit requests in error.
+
+        Sometimes Comchain credit requests are in error because the transaction
+        could not be verified at the time of processing, due to block mining delay.
+
+        This cron will check all credit requests in error to ensure they are still
+        in error.
+
+        It does not reprocess the credit requests, that remain a manual operation.
+        """
+        currencies = self.search([("active", "=", True), ("engine", "=", "comchain")])
+        for alt_currency in currencies:
+            alt_currency._check_credit_requests_in_error()
+
+    def _check_credit_requests_in_error(self) -> None:
+        """Check all credit requests in error for this currency."""
+        self.ensure_one()
+        _logger.info(
+            f"Start checking credit requests in error for alt currency {self.name}.",
+        )
+        credit_requests = self.env["credit.request"].search(
+            [
+                ("alt_currency_id", "=", self.id),
+                ("state", "=", "error"),
+            ]
+        )
+        for credit_request in credit_requests:
+            credit_request.check_still_in_error()
+        _logger.info(
+                f"Check of credit requests in error for alt currency {self.name} finished.",
+        )

--- a/lcc_comchain_base/tests/__init__.py
+++ b/lcc_comchain_base/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_wallet
 from . import test_res_alt_currency_reconversion_cron
 from . import test_utils
+from . import test_credit_request

--- a/lcc_comchain_base/tests/test_credit_request.py
+++ b/lcc_comchain_base/tests/test_credit_request.py
@@ -1,0 +1,118 @@
+import json
+from pyc3l import Pyc3l
+from unittest.mock import patch
+from odoo.addons.component.tests.common import TransactionComponentCase
+
+class TestCreditRequest(TransactionComponentCase):
+    def setUp(self):
+        super().setUp()
+
+        self.ResPartner = self.env["res.partner"]
+        self.ResPartnerBackend = self.env["res.partner.backend"]
+        self.ResAltCurrency = self.env["res.alt.currency"]
+        self.ResCreditRequest = self.env["credit.request"]
+
+        self.comchain_currency_unit_product = self.env.ref(
+            "lcc_lokavaluto_app_connection.product_product_numeric_lcc"
+        ).sudo()
+
+    def _create_alt_currency(self, ident="currency", safe_wallet_partner_id=None):
+        return self.ResAltCurrency.create(
+            {
+                "name": ident,
+                "ident": ident,
+                "active": True,
+                "engine": "comchain",
+                "currency_unit_product_id": self.comchain_currency_unit_product.id,
+            }
+        )
+
+    def _create_res_partner(self, name="John Doe"):
+        return self.ResPartner.create({"name": name})
+
+    def _create_res_partner_backend(self, partner, currency, ident="98765"):
+        return self.ResPartnerBackend.create(
+            {
+                "name": f"comchain:{ident}",
+                "alt_currency_id": currency.id,
+                "partner_id": partner.id,
+                "comchain_id": ident,
+                "comchain_wallet": json.dumps("foo"),
+                "comchain_wallet_pwd": "strong_password",
+                "comchain_message_key": "bar"
+            }
+        )
+
+    def _create_credit_request(self, wallet, amount=100):
+        return self.env["credit.request"].create(
+            {
+                "wallet_id": wallet.id,
+                "amount": amount,
+            }
+        )
+
+    def test_check_still_in_error_1(self):
+        """Test check_still_in_error method when credit request is still in error."""
+
+        # Create data
+        currency = self._create_alt_currency()
+        partner = self._create_res_partner()
+        wallet = self._create_res_partner_backend(partner, currency)
+        credit_request = self._create_credit_request(wallet, amount=100)
+
+        # Simulate credit request in error
+        credit_request.transaction_data = "tx_hash_123"
+        credit_request.state = "error"
+
+        # Mock the check_transaction_content method
+        with patch(
+            "odoo.addons.lcc_comchain_base.models.credit_request.check_transaction_content",
+            return_value="Max retry reached to get transaction info (10 retries)"
+        ):
+            # Check still in error
+            credit_request.check_still_in_error()
+
+            # Assert state is still error
+            self.assertEqual(credit_request.state, "error")
+
+    def test_check_still_in_error_2(self):
+        """Test check_still_in_error method when credit request is no longer in error."""
+
+        # Create data
+        currency = self._create_alt_currency()
+        partner = self._create_res_partner()
+        wallet = self._create_res_partner_backend(partner, currency)
+        credit_request = self._create_credit_request(wallet, amount=100)
+
+        # Simulate credit request in error
+        credit_request.transaction_data = "tx_hash_123"
+        credit_request.state = "error"
+
+        # Mock the check_transaction_content method
+        with patch(
+            "odoo.addons.lcc_comchain_base.models.credit_request.check_transaction_content",
+            return_value=False
+        ):
+            # Check still in error
+            credit_request.check_still_in_error()
+
+            # Assert state is now done
+            self.assertEqual(credit_request.state, "done")
+
+    def test_check_still_in_error_3(self):
+        """Test check_still_in_error method when credit request without transaction_data."""
+
+        # Create data
+        currency = self._create_alt_currency()
+        partner = self._create_res_partner()
+        wallet = self._create_res_partner_backend(partner, currency)
+        credit_request = self._create_credit_request(wallet, amount=100)
+
+        # Simulate credit request in error
+        credit_request.state = "error"
+
+        # Check still in error
+        credit_request.check_still_in_error()
+
+        # Assert state is still error
+        self.assertEqual(credit_request.state, "error")

--- a/lcc_comchain_base/views/credit_request.xml
+++ b/lcc_comchain_base/views/credit_request.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="credit_request_comchain_form_view" model="ir.ui.view">
+        <field name="name">credit.request.comchain.form.view</field>
+        <field name="model">credit.request</field>
+        <field name="inherit_id" ref="lcc_lokavaluto_app_connection.credit_request_view_form" />
+        <field name="priority">0</field>
+        <field name="arch" type="xml">
+          <xpath expr="//div[@name='warning_1']" position="after">
+	    <div>If the field <strong>Transaction message</strong> is filled, please wait 3 minutes and click on button <strong>CHECK ERROR</strong> to verify the transaction status.</div>
+	    <button name="check_still_in_error" string="Check Error" class="oe_highlight me-2" type="object"/>
+          </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/lcc_lokavaluto_app_connection/views/credit_request.xml
+++ b/lcc_lokavaluto_app_connection/views/credit_request.xml
@@ -77,11 +77,14 @@
                     </group>
                     <div class="alert alert-danger" role="alert"
                         attrs="{'invisible': [('state','!=','error')]}">
-                        <div>
+                        <div name="warning_1">
                             <strong>An error status doesn't always mean the credit request
-                                failed.</strong><br /> Before trying again to credit the wallet,
+                            failed.</strong>
+			</div>
+			<div name="warning_2">
+			    Before trying again to credit the wallet,
                             please <strong>check on the transactions database that the request
-                                has not successed.</strong>
+                            has not succeeded.</strong>
                         </div>
                         <button name="try_again"
                             string="Try again"


### PR DESCRIPTION
This PR adds a function to check the error status of the Comchain credit requests, as sometime the error is just due to the delay a Comchain block is built.

It also adds a button to check error status directly from the credit request form view, and a cron to regularly check the errors.