### PR TITLE
[FIX] lcc_members_portal : correct how many2one fields are stored during members registrations

### DIFF
--- a/lcc_members_portal/controllers/portal_organization_registration.py
+++ b/lcc_members_portal/controllers/portal_organization_registration.py
@@ -15,7 +15,7 @@ class PortalOrganizationRegistration(CustomerPortal):
         "city",
         "zipcode",
         "country_id",
-        # "team_id",  # TODO: issue occuring when this field is added. INVESTIGATION NEEDED
+        "team_id",
         "phone",
         "company_email",
         "website_url",
@@ -151,6 +151,12 @@ class PortalOrganizationRegistration(CustomerPortal):
         values.update(
             {"zip": values.pop("zipcode", ""), "website": values.pop("website_url", "")}
         )
+        # HTTP form data comes in as strings, but Odoo ORM requires integers for
+        # Many2one fields. Without this conversion, the value is stored as False,
+        # which breaks base_location's _check_zip constraint.
+        for field in ("country_id", "industry_id", "team_id"):
+            if values.get(field):
+                values[field] = int(values[field])
 
         return values
 
@@ -163,10 +169,7 @@ class PortalOrganizationRegistration(CustomerPortal):
     def send_registration_request(self, **kwargs):
         # Create a new lead
         values = self._compute_organization_form_data(kwargs)
-        lead = request.env["crm.lead"].sudo().create(values)
-        lead.team_id = request.env["crm.team"].browse(
-            kwargs.pop("team_id")
-        )  # TODO: see remark above concerning team_id
+        request.env["crm.lead"].sudo().create(values)
         return request.render(
             "lcc_members_portal.portal_organization_registration_saved", {}
         )

--- a/lcc_members_portal/controllers/portal_organization_renewal.py
+++ b/lcc_members_portal/controllers/portal_organization_renewal.py
@@ -115,6 +115,12 @@ class PortalOrganizationRenewal(CustomerPortal):
         values["name"] = values["company_name"]
         values.update({"zip": values.pop("zipcode", "")})
         values.update({"website": values.pop("website_url", "")})
+        # HTTP form data comes in as strings, but Odoo ORM requires integers for
+        # Many2one fields. Without this conversion, the value is stored as False,
+        # which breaks base_location's _check_zip constraint.
+        for field in ("industry_id",):
+            if values.get(field):
+                values[field] = int(values[field])
 
         return values
 

--- a/lcc_members_portal/controllers/portal_private_registration.py
+++ b/lcc_members_portal/controllers/portal_private_registration.py
@@ -121,6 +121,12 @@ class PortalPrivateRegistration(CustomerPortal):
             }
         )
         values["name"] = values["firstname"] + " " + values["lastname"]
+        # HTTP form data comes in as strings, but Odoo ORM requires integers for
+        # Many2one fields. Without this conversion, the value is stored as False,
+        # which breaks base_location's _check_zip constraint.
+        for field in ("country_id", "team_id", "title"):
+            if values.get(field):
+                values[field] = int(values[field])
         return values
 
     @http.route(

--- a/lcc_members_portal/controllers/website_organization_registration.py
+++ b/lcc_members_portal/controllers/website_organization_registration.py
@@ -14,7 +14,7 @@ class WebsiteOrganizationRegistration(http.Controller):
         "city",
         "zipcode",
         "country_id",
-        # "team_id",  # TODO: issue occuring when this field is added. INVESTIGATION NEEDED
+        "team_id",
         "phone",
         "company_email",
         "website_url",
@@ -129,6 +129,12 @@ class WebsiteOrganizationRegistration(http.Controller):
         values["name"] = values["company_name"]
         values.update({"zip": values.pop("zipcode", "")})
         values.update({"website": values.pop("website_url", "")})
+        # HTTP form data comes in as strings, but Odoo ORM requires integers for
+        # Many2one fields. Without this conversion, the value is stored as False,
+        # which breaks base_location's _check_zip constraint.
+        for field in ("country_id", "industry_id", "team_id"):
+            if values.get(field):
+                values[field] = int(values[field])
         return values
 
     @http.route(
@@ -140,10 +146,7 @@ class WebsiteOrganizationRegistration(http.Controller):
     def send_registration_request(self, **kwargs):
         # Create a new lead
         values = self._compute_web_form_data(kwargs)
-        lead = request.env["crm.lead"].sudo().create(values)
-        lead.team_id = request.env["crm.team"].browse(
-            kwargs.pop("team_id")
-        )  # TODO: see remark above concerning team_id
+        request.env["crm.lead"].sudo().create(values)
         return request.render(
             "lcc_members_portal.website_organization_registration_saved", {}
         )


### PR DESCRIPTION
cf https://lokavaluto.fr/web#id=374&cids=1&model=helpdesk.ticket&view_type=form

The bug : 
HTTP form data is always submitted as strings. When _compute_private_form_data passed country_id, team_id, and title as strings to res.partner.write(), the ORM stored False instead of the expected integer ID for these Many2one fields. Then the `_check_zip` constraint raised a ValidationError because zip_id.city_id.country_id (France) no longer matched the now-empty country_id.

The concerned ValidationError in _check_zip function :
```python
            if rec.zip_id.city_id.country_id != rec.country_id:
                raise ValidationError(
                    _(
                        "The country of the partner %(partner)s differs from that in "
                        "location %(location)s"
                    )
                    % error_dict
                )
```


The fix is to explicitly cast country_id, team_id, and title to int in _compute_private_form_data before writing to the partner.                                     

I started by correcting the route `/membership/subscribe_member` in portal_private_registration.py.
Then I've noticed that the other routes were bugged as well. I've use the same fix for them all.